### PR TITLE
Corrección de algunos códigos de estado

### DIFF
--- a/src/main/java/com/svalero/tripalbumapi/controller/CountryController.java
+++ b/src/main/java/com/svalero/tripalbumapi/controller/CountryController.java
@@ -123,12 +123,12 @@ public class CountryController {
     @ExceptionHandler(CountryNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleCountryNotFoundException(CountryNotFoundException cnfe) {
         logger.info("404: Country not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(cnfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(cnfe.getMessage()));
     }
 
     @ExceptionHandler(InternalServerErrorException.class)
     public ResponseEntity<ErrorResponse> handleInternalServerErrorException(InternalServerErrorException isee) {
         logger.info("500: Internal server error");
-        return ResponseEntity.badRequest().body(ErrorResponse.internalServerError(isee.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.internalServerError(isee.getMessage()));
     }
 }

--- a/src/main/java/com/svalero/tripalbumapi/controller/PlaceController.java
+++ b/src/main/java/com/svalero/tripalbumapi/controller/PlaceController.java
@@ -127,18 +127,18 @@ public class PlaceController {
     @ExceptionHandler(PlaceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handlePlaceNotFoundException(PlaceNotFoundException pnfe) {
         logger.info("404: Place not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
     }
 
     @ExceptionHandler(ProvinceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleProvinceNotFoundException(ProvinceNotFoundException pnfe) {
         logger.info("404: Province not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
     }
 
     @ExceptionHandler(InternalServerErrorException.class)
     public ResponseEntity<ErrorResponse> handleInternalServerErrorException(InternalServerErrorException isee) {
         logger.info("500: Internal server error");
-        return ResponseEntity.badRequest().body(ErrorResponse.internalServerError(isee.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.internalServerError(isee.getMessage()));
     }
 }

--- a/src/main/java/com/svalero/tripalbumapi/controller/ProvinceController.java
+++ b/src/main/java/com/svalero/tripalbumapi/controller/ProvinceController.java
@@ -129,18 +129,18 @@ public class ProvinceController {
     @ExceptionHandler(ProvinceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleProvinceNotFoundException(ProvinceNotFoundException pnfe) {
         logger.info("404: Province not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
     }
 
     @ExceptionHandler(CountryNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleCountryNotFoundException(CountryNotFoundException cnfe) {
         logger.info("404: Country not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(cnfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(cnfe.getMessage()));
     }
 
     @ExceptionHandler(InternalServerErrorException.class)
     public ResponseEntity<ErrorResponse> handleInternalServerErrorException(InternalServerErrorException isee) {
         logger.info("500: Internal server error");
-        return ResponseEntity.badRequest().body(ErrorResponse.internalServerError(isee.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.internalServerError(isee.getMessage()));
     }
 }

--- a/src/main/java/com/svalero/tripalbumapi/controller/UserController.java
+++ b/src/main/java/com/svalero/tripalbumapi/controller/UserController.java
@@ -142,18 +142,18 @@ public class UserController {
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleUserNotFoundException(UserNotFoundException unfe) {
         logger.info("404: User not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(unfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(unfe.getMessage()));
     }
 
     @ExceptionHandler(PlaceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handlePlaceNotFoundException(PlaceNotFoundException pnfe) {
         logger.info("404: Place not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
     }
 
     @ExceptionHandler(InternalServerErrorException.class)
     public ResponseEntity<ErrorResponse> handleInternalServerErrorException(InternalServerErrorException isee) {
         logger.info("500: Internal server error");
-        return ResponseEntity.badRequest().body(ErrorResponse.internalServerError(isee.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.internalServerError(isee.getMessage()));
     }
 }

--- a/src/main/java/com/svalero/tripalbumapi/controller/VisitController.java
+++ b/src/main/java/com/svalero/tripalbumapi/controller/VisitController.java
@@ -109,24 +109,24 @@ public class VisitController {
     @ExceptionHandler(VisitNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleVisitNotFoundException(VisitNotFoundException vnfe) {
         logger.info("404: Visit not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(vnfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(vnfe.getMessage()));
     }
 
     @ExceptionHandler(PlaceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handlePlaceNotFoundException(PlaceNotFoundException pnfe) {
         logger.info("404: Place not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(pnfe.getMessage()));
     }
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleUserNotFoundException(UserNotFoundException unfe) {
         logger.info("404: User not found");
-        return ResponseEntity.badRequest().body(ErrorResponse.resourceNotFound(unfe.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.resourceNotFound(unfe.getMessage()));
     }
 
     @ExceptionHandler(InternalServerErrorException.class)
     public ResponseEntity<ErrorResponse> handleInternalServerErrorException(InternalServerErrorException isee) {
         logger.info("500: Internal server error");
-        return ResponseEntity.badRequest().body(ErrorResponse.internalServerError(isee.getMessage()));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.internalServerError(isee.getMessage()));
     }
 }

--- a/src/main/java/com/svalero/tripalbumapi/exception/BadRequestException.java
+++ b/src/main/java/com/svalero/tripalbumapi/exception/BadRequestException.java
@@ -3,10 +3,6 @@ package com.svalero.tripalbumapi.exception;
 public class BadRequestException extends Exception {
     private static final String DEFAULT_ERROR_MESSAGE = "Bad Request";
 
-    public BadRequestException(String message) {
-        super(message);
-    }
-
     public BadRequestException() {
         super(DEFAULT_ERROR_MESSAGE);
     }

--- a/src/main/java/com/svalero/tripalbumapi/exception/CountryNotFoundException.java
+++ b/src/main/java/com/svalero/tripalbumapi/exception/CountryNotFoundException.java
@@ -3,12 +3,7 @@ package com.svalero.tripalbumapi.exception;
 public class CountryNotFoundException extends Exception {
     private static final String DEFAULT_ERROR_MESSAGE = "Country not found";
 
-    public CountryNotFoundException(String message) {
-        super(message);
-    }
-
     public CountryNotFoundException() {
         super(DEFAULT_ERROR_MESSAGE);
     }
-
 }

--- a/src/main/java/com/svalero/tripalbumapi/exception/ErrorResponse.java
+++ b/src/main/java/com/svalero/tripalbumapi/exception/ErrorResponse.java
@@ -38,6 +38,4 @@ public class ErrorResponse {
     public static ErrorResponse internalServerError(String message) {
         return new ErrorResponse(500, message);
     }
-
 }
-

--- a/src/main/java/com/svalero/tripalbumapi/exception/InternalServerErrorException.java
+++ b/src/main/java/com/svalero/tripalbumapi/exception/InternalServerErrorException.java
@@ -3,10 +3,6 @@ package com.svalero.tripalbumapi.exception;
 public class InternalServerErrorException extends Exception {
     private static final String DEFAULT_ERROR_MESSAGE = "Internal Server Error";
 
-    public InternalServerErrorException(String message) {
-        super(message);
-    }
-
     public InternalServerErrorException() {
         super(DEFAULT_ERROR_MESSAGE);
     }

--- a/src/main/java/com/svalero/tripalbumapi/exception/PlaceNotFoundException.java
+++ b/src/main/java/com/svalero/tripalbumapi/exception/PlaceNotFoundException.java
@@ -3,10 +3,6 @@ package com.svalero.tripalbumapi.exception;
 public class PlaceNotFoundException extends Exception {
     private static final String DEFAULT_ERROR_MESSAGE = "Place not found";
 
-    public PlaceNotFoundException(String message) {
-        super(message);
-    }
-
     public PlaceNotFoundException() {
         super(DEFAULT_ERROR_MESSAGE);
     }

--- a/src/main/java/com/svalero/tripalbumapi/exception/ProvinceNotFoundException.java
+++ b/src/main/java/com/svalero/tripalbumapi/exception/ProvinceNotFoundException.java
@@ -3,10 +3,6 @@ package com.svalero.tripalbumapi.exception;
 public class ProvinceNotFoundException extends Exception {
     private static final String DEFAULT_ERROR_MESSAGE = "Province not found";
 
-    public ProvinceNotFoundException(String message) {
-        super(message);
-    }
-
     public ProvinceNotFoundException() {
         super(DEFAULT_ERROR_MESSAGE);
     }

--- a/src/main/java/com/svalero/tripalbumapi/exception/UserNotFoundException.java
+++ b/src/main/java/com/svalero/tripalbumapi/exception/UserNotFoundException.java
@@ -3,10 +3,6 @@ package com.svalero.tripalbumapi.exception;
 public class UserNotFoundException extends Exception {
     private static final String DEFAULT_ERROR_MESSAGE = "User not found";
 
-    public UserNotFoundException(String message) {
-        super(message);
-    }
-
     public UserNotFoundException() {
         super(DEFAULT_ERROR_MESSAGE);
     }

--- a/src/main/java/com/svalero/tripalbumapi/exception/VisitNotFoundException.java
+++ b/src/main/java/com/svalero/tripalbumapi/exception/VisitNotFoundException.java
@@ -3,10 +3,6 @@ package com.svalero.tripalbumapi.exception;
 public class VisitNotFoundException extends Exception {
     private static final String DEFAULT_ERROR_MESSAGE = "Visit not found";
 
-    public VisitNotFoundException(String message) {
-        super(message);
-    }
-
     public VisitNotFoundException() {
         super(DEFAULT_ERROR_MESSAGE);
     }


### PR DESCRIPTION
Los errores 404 y 500 devolvían un código de estado 400, aunque mostraban el mensaje correcto. Se ha corregido ese fallo.